### PR TITLE
Added support for custom manual pages in the esdoc.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esdoc",
-  "version": "0.5.0-alpha",
+  "version": "0.5.1-alpha",
   "description": "Documentation Generator For JavaScript(ES6)",
   "author": "h13i32maru",
   "homepage": "https://esdoc.org/",

--- a/src/Publisher/Builder/ManualDocBuilder.js
+++ b/src/Publisher/Builder/ManualDocBuilder.js
@@ -1,4 +1,5 @@
 import IceCap from 'ice-cap';
+import path from 'path';
 import fs from 'fs-extra';
 import cheerio from 'cheerio';
 import DocBuilder from './DocBuilder.js';
@@ -32,15 +33,17 @@ export default class ManualDocBuilder extends DocBuilder {
       callback(ice.html, fileName);
     }
 
-    for (let item of manualConfig) {
+    for (const item of manualConfig) {
       if (!item.paths) continue;
-      const fileName = this._getManualOutputFileName(item);
-      const baseUrl = this._getBaseUrl(fileName);
-      ice.load('content', this._buildManual(item), IceCap.MODE_WRITE);
-      ice.load('nav', this._buildManualNav(manualConfig), IceCap.MODE_WRITE);
-      ice.text('title', item.label, IceCap.MODE_WRITE);
-      ice.attr('baseUrl', 'href', baseUrl, IceCap.MODE_WRITE);
-      callback(ice.html, fileName);
+      for (const filePath of item.paths) {
+        const fileName = this._getManualOutputFileName(item, filePath);
+        const baseUrl = this._getBaseUrl(fileName);
+        ice.load('content', this._buildManual(item, filePath), IceCap.MODE_WRITE);
+        ice.load('nav', this._buildManualNav(manualConfig), IceCap.MODE_WRITE);
+        ice.text('title', item.label, IceCap.MODE_WRITE);
+        ice.attr('baseUrl', 'href', baseUrl, IceCap.MODE_WRITE);
+        callback(ice.html, fileName);
+      }
     }
 
     if (this._config.manual.asset) {
@@ -56,16 +59,55 @@ export default class ManualDocBuilder extends DocBuilder {
   _getManualConfig() {
     const m = this._config.manual;
     const manualConfig = [];
-    if (m.overview) manualConfig.push({label: 'Overview', paths: m.overview});
-    if (m.installation) manualConfig.push({label: 'Installation', paths: m.installation});
-    if (m.tutorial) manualConfig.push({label: 'Tutorial', paths: m.tutorial});
-    if (m.usage) manualConfig.push({label: 'Usage', paths: m.usage});
-    if (m.configuration) manualConfig.push({label: 'Configuration', paths: m.configuration});
-    if (m.example) manualConfig.push({label: 'Example', paths: m.example});
-    manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true});
-    if (m.faq) manualConfig.push({label: 'FAQ', paths: m.faq});
-    if (m.changelog) manualConfig.push({label: 'Changelog', paths: m.changelog});
+    if (m.overview) manualConfig.push({label: 'Overview', paths: m.overview, type: 'overview' });
+    if (m.installation) manualConfig.push({label: 'Installation', paths: m.installation, type: 'installation'});
+    if (m.tutorial) manualConfig.push({label: 'Tutorial', paths: m.tutorial, type: 'tutorial'});
+    if (m.usage) manualConfig.push({label: 'Usage', paths: m.usage, type: 'usage'});
+    if (m.configuration) manualConfig.push({label: 'Configuration', paths: m.configuration, type: 'configuration'});
+    if (m.example) manualConfig.push({label: 'Example', paths: m.example, type: 'example'});
+    manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true, type: 'reference'});
+    if (m.faq) manualConfig.push({label: 'FAQ', paths: m.faq, type: 'faq'});
+    if (m.changelog) manualConfig.push({label: 'Changelog', paths: m.changelog, type: 'changelog'});
+    if (Array.isArray(m.customPages)) this._addCustomPages(manualConfig, m.customPages);
     return manualConfig;
+  }
+
+  _validateCustomPageConfig(existingTypes, customPage) {
+    if (typeof customPage.label !== 'string') {
+      console.log('Custom manual page config "label" is not a string, skipping: ', customPage);
+      return {isValid: false};
+    }
+    if (!Array.isArray(customPage.paths)) {
+      console.log('Custom manual page config "paths" is not an array, skipping: ', customPage);
+      return {isValid: false};
+    }
+    const invalidLabelCharacters = /[^\w ]+/g;
+    const badCharacters = customPage.label.match(invalidLabelCharacters);
+    if (badCharacters) {
+      console.log(`Custom manual page config "label" contains invalid characters "${badCharacters}", skipping:`, customPage);
+      return {isValid: false};
+    }
+    const type = customPage.label.replace(/ /g, '_').toLowerCase();
+    if (existingTypes.indexOf(type) >= 0) {
+      console.log('Custom manual page config "label" duplicates existing label, skipping: ', customPage);
+      return {isValid: false};
+    }
+    return {isValid: true, type: type};
+  }
+
+  _addCustomPages(manualConfigs, customPageList) {
+    const existingTypes = [];
+    for (let manualConfig of manualConfigs) {
+      existingTypes.push(manualConfig.type);
+    }
+    for (let customPage of customPageList) {
+      const validationInfo = this._validateCustomPageConfig(existingTypes, customPage);
+      if (validationInfo.isValid) {
+        customPage.type = validationInfo.type;
+        existingTypes.push(validationInfo.type);
+        manualConfigs.push(customPage);
+      }
+    }
   }
 
   /**
@@ -84,11 +126,12 @@ export default class ManualDocBuilder extends DocBuilder {
   /**
    * build manual.
    * @param {ManualConfigItem} item - target manual config item.
+   * @param {string} filePath - target manual file path.
    * @return {IceCap} built manual.
    * @private
    */
-  _buildManual(item) {
-    const html = this._convertMDToHTML(item);
+  _buildManual(item, filePath) {
+    const html = this._convertMDToHTML(filePath);
     const ice = new IceCap(this._readTemplate('manual.html'));
     ice.text('title', item.label);
     ice.load('content', html);
@@ -101,7 +144,7 @@ export default class ManualDocBuilder extends DocBuilder {
       if (!src) return;
       if (src.match(/^http[s]?:/)) return;
       if (src.charAt(0) === '/') return;
-      $el.attr('src', './manual/' + src);
+      $el.attr('src', `./manual/${src}`);
     });
     $root.find('a').each((i, el)=>{
       const $el = cheerio(el);
@@ -110,7 +153,7 @@ export default class ManualDocBuilder extends DocBuilder {
       if (href.match(/^http[s]?:/)) return;
       if (href.charAt(0) === '/') return;
       if (href.charAt(0) === '#') return;
-      $el.attr('href', './manual/' + href);
+      $el.attr('href', `./manual/${href}`);
     });
 
     return $root.html();
@@ -129,35 +172,36 @@ export default class ManualDocBuilder extends DocBuilder {
       const toc = [];
       if (item.references) {
         const identifiers = this._findAllIdentifiersKindGrouping();
-        if (identifiers.class.length) toc.push({label: 'Class', link: 'identifiers.html#class', indent: 'indent-h1'});
-        if (identifiers.interface.length) toc.push({label: 'Interface', link: 'identifiers.html#interface', indent: 'indent-h1'});
-        if (identifiers.function.length) toc.push({label: 'Function', link: 'identifiers.html#function', indent: 'indent-h1'});
-        if (identifiers.variable.length) toc.push({label: 'Variable', link: 'identifiers.html#variable', indent: 'indent-h1'});
-        if (identifiers.typedef.length) toc.push({label: 'Typedef', link: 'identifiers.html#typedef', indent: 'indent-h1'});
-        if (identifiers.external.length) toc.push({label: 'External', link: 'identifiers.html#external', indent: 'indent-h1'});
+        toc.push({label: 'Reference', link: 'identifiers.html', indent: 'indent-h1'});
+        if (identifiers.class.length) toc.push({label: 'Class', link: 'identifiers.html#class', indent: 'indent-h2'});
+        if (identifiers.interface.length) toc.push({label: 'Interface', link: 'identifiers.html#interface', indent: 'indent-h2'});
+        if (identifiers.function.length) toc.push({label: 'Function', link: 'identifiers.html#function', indent: 'indent-h2'});
+        if (identifiers.variable.length) toc.push({label: 'Variable', link: 'identifiers.html#variable', indent: 'indent-h2'});
+        if (identifiers.typedef.length) toc.push({label: 'Typedef', link: 'identifiers.html#typedef', indent: 'indent-h2'});
+        if (identifiers.external.length) toc.push({label: 'External', link: 'identifiers.html#external', indent: 'indent-h2'});
       } else {
-        const fileName = this._getManualOutputFileName(item);
-        const html = this._convertMDToHTML(item);
-        const $root = cheerio.load(html).root();
-        const isHRise = $root.find('h1').length === 0;
-        $root.find('h1,h2,h3,h4,h5').each((i, el)=>{
-          const $el = cheerio(el);
-          const label = $el.text();
-          const link = `${fileName}#${$el.attr('id')}`;
-          let indent;
-          if (isHRise) {
-            const tagName = `h${parseInt(el.tagName.charAt(1), 10) - 1}`;
-            indent = `indent-${tagName}`;
-          } else {
-            indent = `indent-${el.tagName.toLowerCase()}`;
-          }
-          toc.push({label, link, indent});
-        });
+        for (const filePath of item.paths) {
+          const fileName = this._getManualOutputFileName(item, filePath);
+          const html = this._convertMDToHTML(filePath);
+          const $root = cheerio.load(html).root();
+          const h1Count = $root.find('h1').length;
+
+          $root.find('h1,h2,h3,h4,h5').each((i, el)=>{
+            const $el = cheerio(el);
+            const label = $el.text();
+            const indent = `indent-${el.tagName.toLowerCase()}`;
+
+            let link = `${fileName}#${$el.attr('id')}`;
+            if (el.tagName.toLowerCase() === 'h1' && h1Count === 1) link = fileName;
+
+            toc.push({label, link, indent});
+          });
+        }
       }
 
-      ice.attr('manual', 'data-toc-name', item.label.toLowerCase());
-      ice.text('title', item.label);
-      ice.attr('title', 'href', this._getManualOutputFileName(item));
+      ice.attr('manual', 'data-toc-name', item.type);
+      // ice.text('title', item.label);
+      // ice.attr('title', 'href', this._getManualOutputFileName(item));
       ice.loop('manualNav', toc, (i, item, ice)=>{
         ice.attr('manualNav', 'class', item.indent);
         ice.text('link', item.label);
@@ -171,28 +215,27 @@ export default class ManualDocBuilder extends DocBuilder {
   /**
    * get manual file name.
    * @param {ManualConfigItem} item - target manual config item.
+   * @param {string} filePath - target manual markdown file path.
    * @returns {string} file name.
    * @private
    */
-  _getManualOutputFileName(item) {
+  _getManualOutputFileName(item, filePath) {
     if (item.fileName) return item.fileName;
-    return `manual/${item.label.toLowerCase()}.html`;
+
+    const fileName = path.parse(filePath).name;
+    return `manual/${item.type}/${fileName}.html`;
   }
 
   /**
    * convert markdown to html.
    * if markdown has only one ``h1`` and it's text is ``item.label``, remove the ``h1``.
    * because duplication ``h1`` in output html.
-   * @param {ManualConfigItem} item - target.
+   * @param {string} filePath - target.
    * @returns {string} converted html.
    * @private
    */
-  _convertMDToHTML(item) {
-    const contents = [];
-    for (let path of item.paths) {
-      contents.push(fs.readFileSync(path).toString());
-    }
-    const content = contents.join('\n\n');
+  _convertMDToHTML(filePath) {
+    const content = fs.readFileSync(filePath).toString();
     const html = markdown(content);
     const $root = cheerio.load(html).root();
     return $root.html();

--- a/test/fixture/esdoc.json
+++ b/test/fixture/esdoc.json
@@ -21,6 +21,14 @@
     "configuration": ["./test/fixture/manual/configuration.md"],
     "example": ["./test/fixture/manual/example.md"],
     "faq": ["./test/fixture/manual/faq.md"],
-    "changelog": ["./test/fixture/CHANGELOG.md"]
+    "changelog": ["./test/fixture/CHANGELOG.md"],
+    "customPages": [
+      {"label": "Custom Page 1", "paths": ["./test/fixture/manual/customPage1.md"]},
+      {"label": "Custom Page 2", "paths": ["./test/fixture/manual/customPage2.md"]},
+      {"label": 1, "paths": ["badTypeOfLabel"]},
+      {"label": "bad typeof path", "paths": "badTypeOfPath"},
+      {"label": "B@d label characters", "paths": ["badLabelCharacters"]},
+      {"label": "Overview", "paths": ["duplicateLabel"]}
+    ]
   }
 }

--- a/test/fixture/manual/customPage1.md
+++ b/test/fixture/manual/customPage1.md
@@ -1,0 +1,2 @@
+# Custom Page 1
+Foo 1

--- a/test/fixture/manual/customPage2.md
+++ b/test/fixture/manual/customPage2.md
@@ -1,0 +1,2 @@
+# Custom Page 2
+Foo 2

--- a/test/src/BuilderTest/ManualDocTest.js
+++ b/test/src/BuilderTest/ManualDocTest.js
@@ -21,16 +21,9 @@ describe('Manual:', ()=>{
       assert.includes(doc, '[data-ice="manual"]:nth-of-type(7)', 'Reference');
       assert.includes(doc, '[data-ice="manual"]:nth-of-type(8)', 'FAQ');
       assert.includes(doc, '[data-ice="manual"]:nth-of-type(9)', 'Changelog');
-
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(1) .manual-toc-title a', 'manual/overview.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(2) .manual-toc-title a', 'manual/installation.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(3) .manual-toc-title a', 'manual/tutorial.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(4) .manual-toc-title a', 'manual/usage.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(5) .manual-toc-title a', 'manual/configuration.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(6) .manual-toc-title a', 'manual/example.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(7) .manual-toc-title a', 'identifiers.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(8) .manual-toc-title a', 'manual/faq.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(9) .manual-toc-title a', 'manual/changelog.html', 'href');
+      assert.includes(doc, '[data-ice="manual"]:nth-of-type(10)', 'Custom Page 1');
+      assert.includes(doc, '[data-ice="manual"]:nth-of-type(11)', 'Custom Page 2');
+      assert.notFound(doc, '[data-ice="manual"]:nth-of-type(12)');
     });
   });
 
@@ -40,161 +33,178 @@ describe('Manual:', ()=>{
 
     // overview
     find(doc, '.content [data-ice="manual"]:nth-of-type(1)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Overview');
-
       assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Overview');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'Feature');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3)', 'Demo');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(4)', 'License');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(5)', 'Author');
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/overview.html#overview', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/overview.html#feature', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3) a', 'manual/overview.html#demo', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(4) a', 'manual/overview.html#license', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(5) a', 'manual/overview.html#author', 'href');
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/overview/overview.html', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/overview/overview.html#feature', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3) a', 'manual/overview/overview.html#demo', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(4) a', 'manual/overview/overview.html#license', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(5) a', 'manual/overview/overview.html#author', 'href');
     });
 
     // installation
     find(doc, '.content [data-ice="manual"]:nth-of-type(2)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Installation');
-
       assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Installation');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'indent 2');
       assert.includes(doc, '.indent-h3[data-ice="manualNav"]:nth-of-type(3)', 'indent 3');
       assert.includes(doc, '.indent-h4[data-ice="manualNav"]:nth-of-type(4)', 'indent 4');
       assert.includes(doc, '.indent-h5[data-ice="manualNav"]:nth-of-type(5)', 'indent 5');
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/installation.html#installation', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/installation.html#indent-2', 'href');
-      assert.includes(doc, '.indent-h3[data-ice="manualNav"]:nth-of-type(3) a', 'manual/installation.html#indent-3', 'href');
-      assert.includes(doc, '.indent-h4[data-ice="manualNav"]:nth-of-type(4) a', 'manual/installation.html#indent-4', 'href');
-      assert.includes(doc, '.indent-h5[data-ice="manualNav"]:nth-of-type(5) a', 'manual/installation.html#indent-5', 'href');
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/installation/installation.html', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/installation/installation.html#indent-2', 'href');
+      assert.includes(doc, '.indent-h3[data-ice="manualNav"]:nth-of-type(3) a', 'manual/installation/installation.html#indent-3', 'href');
+      assert.includes(doc, '.indent-h4[data-ice="manualNav"]:nth-of-type(4) a', 'manual/installation/installation.html#indent-4', 'href');
+      assert.includes(doc, '.indent-h5[data-ice="manualNav"]:nth-of-type(5) a', 'manual/installation/installation.html#indent-5', 'href');
     });
 
     // tutorial
     find(doc, '.content [data-ice="manual"]:nth-of-type(3)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Tutorial');
+      assert.includes(doc, '[data-ice="manualNav"]:nth-of-type(1) a', 'manual/tutorial/tutorial.html', 'href');
     });
 
     // usage
     find(doc, '.content [data-ice="manual"]:nth-of-type(4)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Usage');
+      assert.includes(doc, '[data-ice="manualNav"]:nth-of-type(1) a', 'manual/usage/usage1.html', 'href');
+      assert.includes(doc, '[data-ice="manualNav"]:nth-of-type(2) a', 'manual/usage/usage2.html', 'href');
+      assert.includes(doc, '[data-ice="manualNav"]:nth-of-type(3) a', 'manual/usage/usage2.html#h2-in-usage2', 'href');
+      assert.includes(doc, '[data-ice="manualNav"]:nth-of-type(4) a', 'manual/usage/usage2.html#h3-in-usage2', 'href');
     });
 
     // configuration
     find(doc, '.content [data-ice="manual"]:nth-of-type(5)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Configuration');
+      assert.includes(doc, '[data-ice="manualNav"]:nth-of-type(1) a', 'manual/configuration/configuration.html', 'href');
     });
 
     // example
     find(doc, '.content [data-ice="manual"]:nth-of-type(6)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Example');
-
       assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Example');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'Minimum Config');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3)', 'Integration Test Code Into Documentation');
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/example.html#example', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/example.html#minimum-config', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3) a', 'manual/example.html#integration-test-code-into-documentation', 'href');
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/example/example.html', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/example/example.html#minimum-config', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3) a', 'manual/example/example.html#integration-test-code-into-documentation', 'href');
     });
 
     // reference
     find(doc, '.content [data-ice="manual"]:nth-of-type(7)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Reference');
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Reference');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'Class');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3)', 'Interface');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(4)', 'Function');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(5)', 'Variable');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(6)', 'Typedef');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(7)', 'External');
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Class');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(2)', 'Interface');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(3)', 'Function');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(4)', 'Variable');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(5)', 'Typedef');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(6)', 'External');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'identifiers.html#class', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(2) a', 'identifiers.html#interface', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(3) a', 'identifiers.html#function', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(4) a', 'identifiers.html#variable', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(5) a', 'identifiers.html#typedef', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(6) a', 'identifiers.html#external', 'href');
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'identifiers.html', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'identifiers.html#class', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3) a', 'identifiers.html#interface', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(4) a', 'identifiers.html#function', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(5) a', 'identifiers.html#variable', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(6) a', 'identifiers.html#typedef', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(7) a', 'identifiers.html#external', 'href');
     });
 
     // faq
     find(doc, '.content [data-ice="manual"]:nth-of-type(8)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'FAQ');
-
       assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'FAQ');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'Goal');
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/faq.html#faq', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/faq.html#goal', 'href');
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/faq/faq.html', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/faq/faq.html#goal', 'href');
     });
 
     // changelog
     find(doc, '.content [data-ice="manual"]:nth-of-type(9)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Changelog');
-
       assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Changelog');
       assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', '0.0.1');
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/changelog.html#changelog', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/changelog.html#0-0-1', 'href');
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/changelog/CHANGELOG.html', 'href');
+      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/changelog/CHANGELOG.html#0-0-1', 'href');
+    });
+
+    // custom page 1
+    find(doc, '.content [data-ice="manual"]:nth-of-type(10)', (doc)=>{
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/custom_page_1/customPage1.html', 'href');
+    });
+
+    // custom page 2
+    find(doc, '.content [data-ice="manual"]:nth-of-type(11)', (doc)=>{
+      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/custom_page_2/customPage2.html', 'href');
     });
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has overview', ()=>{
-    const doc = readDoc('manual/overview.html');
+    const doc = readDoc('manual/overview/overview.html');
     assert.includes(doc, '.github-markdown h1', 'Overview');
     assert.includes(doc, '.github-markdown [data-ice="content"]', 'ESDoc is a documentation generator for JavaScript(ES6).');
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has installation', ()=>{
-    const doc = readDoc('manual/installation.html');
+    const doc = readDoc('manual/installation/installation.html');
     assert.includes(doc, '.github-markdown h1', 'Installation');
     assert.includes(doc, '.github-markdown [data-ice="content"]', 'npm install -g esdoc');
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has usage', ()=>{
-    const doc = readDoc('manual/usage.html');
+    const doc = readDoc('manual/usage/usage1.html');
     assert.includes(doc, '.github-markdown h1:nth-of-type(1)', 'Usage');
     assert.includes(doc, '.github-markdown [data-ice="content"]', 'esdoc -c esdoc.json');
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has tutorial', ()=>{
-    const doc = readDoc('manual/tutorial.html');
+    const doc = readDoc('manual/tutorial/tutorial.html');
     assert.includes(doc, '.github-markdown h1', 'Tutorial');
     assert.includes(doc, '.github-markdown [data-ice="content"]', 'this is tutorial');
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has configuration', ()=>{
-    const doc = readDoc('manual/configuration.html');
+    const doc = readDoc('manual/configuration/configuration.html');
     assert.includes(doc, '.github-markdown h1', 'Configuration');
     assert.includes(doc, '.github-markdown [data-ice="content"]', 'this is configuration');
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has example', ()=>{
-    const doc = readDoc('manual/example.html');
+    const doc = readDoc('manual/example/example.html');
     assert.includes(doc, '.github-markdown h1', 'Example');
     assert.includes(doc, '.github-markdown [data-ice="content"] h2:nth-of-type(1)', 'Minimum Config');
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has faq', ()=>{
-    const doc = readDoc('manual/faq.html');
+    const doc = readDoc('manual/faq/faq.html');
     assert.includes(doc, '.github-markdown h1', 'FAQ');
     assert.includes(doc, '.github-markdown [data-ice="content"]', 'ESDoc has two goals.');
   });
 
   /** @test {ManualDocBuilder#_buldManual} */
   it('has changelog', ()=>{
-    const doc = readDoc('manual/changelog.html');
+    const doc = readDoc('manual/changelog/CHANGELOG.html');
     assert.includes(doc, '.github-markdown h1', 'Changelog');
     assert.includes(doc, '.github-markdown [data-ice="content"] h2:nth-of-type(1)', '0.0.1');
+  });
+
+  /** @test {ManualDocBuilder#_buldManual} */
+  it('has custom page 1', ()=>{
+    const doc = readDoc('manual/custom_page_1/customPage1.html');
+    assert.includes(doc, '.github-markdown h1', 'Custom Page 1');
+    assert.includes(doc, '.github-markdown [data-ice="content"]', 'Foo 1');
+  });
+
+  /** @test {ManualDocBuilder#_buldManual} */
+  it('has custom page 2', ()=>{
+    const doc = readDoc('manual/custom_page_2/customPage2.html');
+    assert.includes(doc, '.github-markdown h1', 'Custom Page 2');
+    assert.includes(doc, '.github-markdown [data-ice="content"]', 'Foo 2');
   });
 });

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -56,6 +56,13 @@ _assert.notIncludes = function($el, selector, expect, attr) {
   assert(actual.includes(expect) === false, `selector: "${selector}"`);
 };
 
+_assert.notFound = function($el, selector) {
+  if (selector) {
+    const $els = $el.find(selector);
+    if ($els.length) _assert(false, `node is found. selector = "${selector}"`);
+  }
+};
+
 export var assert = _assert;
 
 const consoleLog = console.log;


### PR DESCRIPTION
- The format for these is `"manual": {"customPages": [{"label": "custom label", "paths": ["customPath.md"]}, ...]}`
- Validates if a custom page definition is bad and outputs warning as to why, indicating it is being skipped
- Includes updates to the tests